### PR TITLE
Changes to build for Montavista Linux 4.0 (mvl40)

### DIFF
--- a/Release/cmake/cpprest_find_openssl.cmake
+++ b/Release/cmake/cpprest_find_openssl.cmake
@@ -41,7 +41,11 @@ function(cpprest_find_openssl)
       # This should prevent linking against the system provided 0.9.8y
       set(_OPENSSL_VERSION "")
     endif()
-    find_package(OpenSSL 1.0.0 REQUIRED)
+    # Montavista environment only ships libssl 0.9.7.
+    # Relax this check so we can build for that platform. 
+    # This (ab)use is OK since that platform will never actually use this package
+    # and it's only included to avoid issues with missing symbols. 
+    find_package(OpenSSL 0.9.0 REQUIRED)
 
     INCLUDE(CheckCXXSourceCompiles)
     set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -280,7 +280,11 @@ public:
         // Check to set host name for Server Name Indication (SNI)
         if (config.is_tlsext_sni_enabled())
         {
+// Our mvl40 environment has an ancient version of openssl. So ancient that this function doesn't exist.
+// Since this library will never do anything on that platform, just ignore it.
+#ifndef SPIRENT_MVL40_COMPATIBILITY
             SSL_set_tlsext_host_name(m_ssl_stream->native_handle(), &m_cn_hostname[0]);
+#endif
         }
 
         m_ssl_stream->async_handshake(type, handshake_handler);


### PR DESCRIPTION
For some context: the IL needs to use this project now, too. Keeping the IL version in `stc-il` branch to decouple IL and BLL versions/modifications. Instructions in perforce will refer to this repo and `stc-il` branch in the "how to build" section. The library will be vendored (i.e. built out of tree and binary artifacts checked in to perforce.)

These modifications are required for the library to build on our oldest (but still supported) IL platform. The other platforms build it with no modifications.

* Relax check for OpenSSL version. mvl40 ships an ancient version of OpenSSL.
* #ifdef out a function not present in mvl40 version of OpenSSL.

NOTE: these changes must not be submitted upstream. They will laugh at us.